### PR TITLE
Could not close code editor

### DIFF
--- a/panel/page.js
+++ b/panel/page.js
@@ -174,7 +174,7 @@
       // save
       case 0:
       codeEditor.save();
-      event.returnValue = true;
+      // event.returnValue = true;
       return;
 
       // cancel
@@ -184,7 +184,7 @@
 
       // don't save
       case 2:
-      event.returnValue = true;
+      // event.returnValue = true;
       return;
     }
   });


### PR DESCRIPTION
Electron 降级后，code-editor 在 windows 平台上无法关闭。

原因是这个版本的 electron 的 event.returnValue 是一个空字符串，更改为 false 或者 true 后直接识别成终止事件。造成窗口无法关闭。

@nantas @jwu 
